### PR TITLE
make search for Sample tags specific to subnodes of Data

### DIFF
--- a/R/readNULISAseq.R
+++ b/R/readNULISAseq.R
@@ -452,7 +452,7 @@ readNULISAseq <- function(file,
     ###########################
     # save Data section
     ###########################
-    SampleData <- xml2::xml_find_all(xml, './/Sample')
+    SampleData <- xml2::xml_find_all(xml, './/Data//Sample')
     # save matching / non-matching
     matchNonMatch <- do.call(rbind, xml2::xml_attrs(SampleData))
     matchNonMatch <- as.data.frame(matchNonMatch)


### PR DESCRIPTION
This pull request includes a small change to the `readNULISAseq` function in `R/readNULISAseq.R`. The XPath query used to locate sample data in the XML file has been updated to ensure it targets structure specifically within Data.

* [`R/readNULISAseq.R`](diffhunk://#diff-3b409e7dfae37c52cb7f689943b243cce5c24c1df45866e2a1036a42a05c977cL455-R455): Modified the XPath query in the `SampleData` assignment from `'.//Sample'` to `'.//Data//Sample'` to accurately locate the sample nodes within the XML structure.