### PR TITLE
docs(QC): fix 'Interal' -> 'Internal' in QC report section title

### DIFF
--- a/vignettes/book/02-quality-control.Rmd
+++ b/vignettes/book/02-quality-control.Rmd
@@ -62,7 +62,7 @@ Visual representation of sample placement on 96-well plates showing:
 The report provides detailed summaries for overall reads and each type of control sample:
  <img src="figures/QC report/Read Summary.png" style="width:100%; max-width:800px;">
 
-#### Interal Controls (IC)
+#### Internal Controls (IC)
 The IC is an exogenous reporter protein added to each well for well-to-well normalization and assessing the uniformity of the assay run.
  <img src="figures/QC report/Read Summary IC.png" style="width:100%; max-width:800px;">
  


### PR DESCRIPTION
## Summary

Minor typo in `vignettes/book/02-quality-control.Rmd` (corresponds to published docs section 2.3.2.1):

Before:
```
#### Interal Controls (IC)
```

After:
```
#### Internal Controls (IC)
```

The body of the section already describes the *Internal Control* (IC) as the exogenous reporter protein, so just the heading was misspelled.

Closes #174

## Testing

Doc-only change.